### PR TITLE
Change lookup from PORT to DYNO in index.js -> isHeroku

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ EveryPaaS.prototype.detect = function(env, dcf) {
 EveryPaaS.prototype.isHeroku = function (env) {
   var env = env || this.herokuEnvironment
 
-  return (env && (env.PORT !== undefined && env.PAAS_NAME !== "strider"))
+  return (env && (env.DYNO !== undefined && env.PAAS_NAME !== "strider"))
 }
 
 EveryPaaS.prototype.getDotCloud = function(filename) {
@@ -96,7 +96,7 @@ EveryPaaS.prototype.getMongodbUrl = function() {
 
 //
 // ## Return an argument list which can be applied to nodemailer's createTransport function
-// 
+//
 EveryPaaS.prototype.getSMTP = function() {
 
   if (this.isHeroku()) {


### PR DESCRIPTION
The isHeroku() lookup failed for me in a fresh install of strider CI. Investigating further it seems like PORT wasn't set by Heroku when I tried to get the MONGO_URI environment variable first ... and everypaas.paas was emited as NONE due to that.

I switched from PORT to DYNO for the lookup and it solved my issue. 
